### PR TITLE
FIX: resize being skipped if only new width or height provided

### DIFF
--- a/src/ImageShortcodeHandler.php
+++ b/src/ImageShortcodeHandler.php
@@ -57,18 +57,31 @@ class ImageShortcodeHandler extends ImageShortcodeProvider
         $image = $record;
         $width = null;
         $height = null;
-        if ($record instanceof Image) {
-            $width = isset($args['width']) ? (int) $args['width'] : null;
-            $height = isset($args['height']) ? (int) $args['height'] : null;
-            $hasCustomDimensions = ($width && $height);
-            if ($hasCustomDimensions && (($width != $record->getWidth()) || ($height != $record->getHeight()))) {
-                $resized = $record->ResizedImage($width, $height);
-                // Make sure that the resized image actually returns an image
-                if ($resized) {
-                    $image = $resized;
-                }
-            }
-        }
+		if ($record instanceof Image)
+		{
+			$baseWidth = $record->getWidth();
+			$baseHeight = $record->getHeight();
+			$resized = null;
+			$width = isset($args['width']) ? (int) $args['width'] : null;
+			$height = isset($args['height']) ? (int) $args['height'] : null;
+
+			if (empty($height) && $width && $width !== $baseWidth) {
+				$resized = $record->ScaleMaxWidth($width, $height);
+			}
+			elseif (empty($width) && $height && $height !== $baseHeight) {
+				$resized = $record->ScaleMaxHeight($width, $height);
+			}
+			elseif ($width && $height && ($width !== $baseWidth || $height !== $baseHeight)) {
+				$resized = $record->ResizedImage($width, $height);
+			}
+
+			// Make sure that the resized image actually returns an image
+			if ($resized) {
+				$image = $resized;
+				$width = $image->getWidth();
+				$height = $image->getHeight();
+			}
+		}
 
         // Determine whether loading="lazy" is set
         $args = self::updateLoadingValue($args, $width, $height);


### PR DESCRIPTION
The existing functionality checks the shortcode params for _both_ width and height, and only resizes the image if they are present.

I have a site of instances where the shortcode only includes the width, resulting in no resizing taking in place.

This snippet continues the existing behaviour if both dimensions are provided, but utilises ScaleWidth or ScaleHeight rather than ResizedImage if a custom width or height is provided alone respectively.

If the resized image then exists, the snippet resets both the in-method `$width` and `$height` variables (as even if only one dimension was in the `$args` array we can now know the other dimension) so that the values are included in the call that determines the value of the `loading` attribute. (Without this, even after handling resize for only a supplied width, no `loading="lazy"` was being added because in-method it had no value for `$height`. 